### PR TITLE
Fix potential memleak in lib and wm2

### DIFF
--- a/src/lib/datapipeline/src/dppline.c
+++ b/src/lib/datapipeline/src/dppline.c
@@ -2119,6 +2119,7 @@ bool dpp_get_report2(uint8_t **pbuff, size_t suggest_sz, uint32_t *packed_sz)
     if (0 == dpp_get_queue_elements())
     {
         LOG(DEBUG, "get_report: queue depth zero");
+        free(buff);
         return false;
     }
 

--- a/src/wm2/src/wm2_radio.c
+++ b/src/wm2/src/wm2_radio.c
@@ -1127,7 +1127,7 @@ wm2_op_clients(const struct schema_Wifi_Associated_Clients *clients,
                             num, vstate.associated_clients_len,
                             sizeof(*clients),
                             strncasecmp))
-        return;
+        goto free;
 
     LOGI("%s: syncing clients", vif);
 


### PR DESCRIPTION
The possible memleak issues were detected by static analysis tool: scan-build


