### PR TITLE
lib: fix compiler error

### DIFF
--- a/src/lib/inet/src/inet_target.c
+++ b/src/lib/inet/src/inet_target.c
@@ -588,9 +588,11 @@ inet_t *if_inet_new(const char *ifname, enum if_type type)
             nif = inet_vif_new(ifname);
             break;
 
+#if defined(CONFIG_INET_GRE_USE_GRETAP)
         case IF_TYPE_GRE:
             nif = inet_gre_new(ifname);
             break;
+#endif
 
         default:
             /* Unsupported types */


### PR DESCRIPTION
With CONFIG_INET_GRE_USE_GRETAP disable, there is a compiler error as below

opensync/src/lib/inet/src/inet_target.c:592: undefined reference to `inet_gre_new'
collect2: error: ld returned 1 exit status
build/unit-build.mk:496: recipe for target 'work/native-ubuntu16.04-x86_64/bin/nm' failed
make: *** [work/native-ubuntu16.04-x86_64/bin/nm] Error 1

Added flag to compile out inet_gre_new() when INET_GRE_USE_GRETAP not defined.