### PR TITLE
bm: add FALLTHROUGH annotation to bm_stats_rssi_report_send()

### DIFF
--- a/src/bm/src/bm_stats_rssi.c
+++ b/src/bm/src/bm_stats_rssi.c
@@ -452,6 +452,7 @@ bool bm_stats_rssi_report_send(
             {
                 case REPORT_TYPE_NONE:
                     report_ctx->report_type = REPORT_TYPE_RAW;
+                    FALLTHROUGH;
                 case REPORT_TYPE_RAW:
                     bm_stats_rssi_report_calculate_raw(
                             rssi_ctx,

--- a/src/lib/const/inc/const.h
+++ b/src/lib/const/inc/const.h
@@ -278,7 +278,7 @@ extern bool             _c_get_param_by_key(c_item_t *list, int list_sz, int key
 
 // Handle error: this statement may fall through [-Werror=implicit-fallthrough=]
 #if (defined(__GNUC__) && __GNUC_PREREQ(7,0))
-#define FALLTHROUGH __attribute__((fallthrough));
+#define FALLTHROUGH __attribute__((fallthrough))
 #else
 #define FALLTHROUGH
 #endif


### PR DESCRIPTION
Also remove unnecessary semi-colon from FALLTHROUGH definition.
