### PR TITLE
osn: nfm: Delete Netfilter chain fails

### DIFF
--- a/src/lib/osn/src/osn_fw.c
+++ b/src/lib/osn/src/osn_fw.c
@@ -227,7 +227,7 @@ static bool osfw_nfchain_del(struct osfw_nfchain *self)
 	}
 
 	free(self);
-	return false;
+	return true;
 }
 
 static struct osfw_nfchain *osfw_nfchain_add(struct ds_dlist *parent, const char *chain)

--- a/src/nfm/src/nfm_osfw.c
+++ b/src/nfm/src/nfm_osfw.c
@@ -194,13 +194,13 @@ bool nfm_osfw_del_chain(int family, const char *table, const char *chain)
 		LOGE("Delete firewall chain: invalid parameters");
 		return false;
 	} else if (!nfm_osfw_is_valid_chain(chain)) {
-		LOGD("Add firewall chain: %s is not a valid chain - ignore it", chain);
+		LOGD("Delete firewall chain: %s is not a valid chain - ignore it", chain);
 		return true;
 	}
 
 	errcode = osfw_chain_del(family, nfm_osfw_convert_table(table), chain);
 	if (!errcode) {
-		LOGE("Add firewall chain failed");
+		LOGE("Delete firewall chain failed");
 		return false;
 	}
 


### PR DESCRIPTION
The OSN component for tehe firewall always returns false in the
function to delete a chain.

The function in case of succes returns false instead of true, this
commit fix this invalid behavior.
Clean logs messages in NFM when a chain is deleted.