### PR TITLE
Allow to configure the frequency of statistics publishing by the SM/QM

### DIFF
--- a/src/qm/src/qm.h
+++ b/src/qm/src/qm.h
@@ -70,6 +70,7 @@ bool qm_mqtt_init(void);
 void qm_mqtt_stop(void);
 void qm_mqtt_set(const char *broker, const char *port, const char *topic, const char *qos, int compress);
 void qm_mqtt_set_log_interval(int log_interval);
+void qm_mqtt_set_agg_stats_interval(int agg_stats_interval);
 bool qm_mqtt_is_connected();
 bool qm_mqtt_config_valid();
 bool qm_mqtt_send_message(qm_item_t *qi, qm_response_t *res);

--- a/src/qm/src/qm_ovsdb.c
+++ b/src/qm/src/qm_ovsdb.c
@@ -64,6 +64,7 @@ void callback_AWLAN_Node(ovsdb_update_monitor_t *mon,
     const char  *mqtt_port = NULL;
     int         mqtt_compress = 0;
     int         log_interval = 0;
+    int         agg_stats_interval = 0;
 
     LOG(DEBUG, "%s %d %d", __FUNCTION__, mon->mon_type,
             awlan ? awlan->mqtt_settings_len : 0);
@@ -102,6 +103,10 @@ void callback_AWLAN_Node(ovsdb_update_monitor_t *mon,
                 log_interval = atoi(val);
                 if (log_interval < 0) log_interval = 0;
             }
+            else if (strcmp(key, "agg_stats_interval") == 0)
+            {
+                agg_stats_interval = atoi(val);
+            }
             else
             {
                 LOG(ERR, "Unkown MQTT option: %s", key);
@@ -111,6 +116,7 @@ void callback_AWLAN_Node(ovsdb_update_monitor_t *mon,
 
     qm_mqtt_set(mqtt_broker, mqtt_port, mqtt_topic, mqtt_qos, mqtt_compress);
     qm_mqtt_set_log_interval(log_interval);
+    qm_mqtt_set_agg_stats_interval(agg_stats_interval);
 }
 
 

--- a/src/sm/src/sm.h
+++ b/src/sm/src/sm.h
@@ -47,8 +47,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "target.h"
 #include "dppline.h"
 
-#define STATS_MQTT_INTERVAL     5.0 /* Report interval in seconds -- float */
-
 struct sm_cxt {
     struct          ev_io nl_watcher;
     int             nl_fd;
@@ -135,6 +133,7 @@ int sm_init_nl(struct sm_cxt *cxt);
 
 bool sm_mqtt_init(void);
 void sm_mqtt_set(const char *broker, const char *port, const char *topic, const char *qos, int compress);
+void sm_mqtt_interval_set(int interval);
 void sm_mqtt_stop(void);
 
 #ifdef CONFIG_SM_CAPACITY_QUEUE_STATS

--- a/src/sm/src/sm_capacity_report.c
+++ b/src/sm/src/sm_capacity_report.c
@@ -433,6 +433,12 @@ void sm_capacity_update (EV_P_ ev_timer *w, int revents)
            we should not exit the processing therefore we
            skip this sample and send the report
          */
+        return;
+    }
+
+    if (capacity_ctx->request.reporting_interval == -1)
+    {
+        sm_capacity_report_send(capacity_ctx);
     }
 }
 
@@ -561,8 +567,10 @@ bool sm_capacity_stats_process (
             sm_capacity_update_timer_set(update_timer, true);
         }
 
-        report_timer->repeat = request_ctx->reporting_interval;
-        sm_capacity_report_timer_set(report_timer, true);
+        if (request_ctx->reporting_interval != -1) {
+            report_timer->repeat = request_ctx->reporting_interval;
+            sm_capacity_report_timer_set(report_timer, true);
+        }
         capacity_ctx->report_ts = get_timestamp();
 
         LOG(INFO,

--- a/src/sm/src/sm_device_report.c
+++ b/src/sm/src/sm_device_report.c
@@ -383,7 +383,9 @@ bool sm_device_report_request(
 
     if (request_ctx->reporting_interval) {
         device_ctx->report_ts = get_timestamp();
-        report_timer->repeat = request_ctx->reporting_interval;
+        report_timer->repeat = request_ctx->reporting_interval == -1 ?
+           1 : request_ctx->reporting_interval;
+
         dpp_device_report_timer_set(report_timer, true);
         if(request_ctx->sampling_interval == 0)
         {

--- a/src/sm/src/sm_neighbor_report.c
+++ b/src/sm/src/sm_neighbor_report.c
@@ -758,6 +758,10 @@ void sm_neighbor_stats_results(
             if (channel_ctx->chan_index >= channel_ctx->chan_num) {
                 channel_ctx->chan_index = 0;
             }
+
+            if (neighbor_ctx->request.reporting_interval == -1) {
+                sm_neighbor_report_send(neighbor_ctx);
+            }
             break;
         case RADIO_SCAN_TYPE_FULL: /* Send report */
             sm_neighbor_report_send(neighbor_ctx);
@@ -1068,8 +1072,10 @@ bool sm_neighbor_stats_process (
             sm_neighbor_update_timer_set(update_timer, true);
         }
 
-        report_timer->repeat = request_ctx->reporting_interval;
-        sm_neighbor_report_timer_set(report_timer, true);
+        if (request_ctx->reporting_interval != -1) {
+            report_timer->repeat = request_ctx->reporting_interval;
+            sm_neighbor_report_timer_set(report_timer, true);
+        }
         neighbor_ctx->report_ts = get_timestamp();
 
         LOG(INFO,

--- a/src/sm/src/sm_ovsdb.c
+++ b/src/sm/src/sm_ovsdb.c
@@ -257,6 +257,23 @@ bool sm_enumerate_stats_config(sm_stats_config_t *stats)
 }
 
 static
+void sm_update_mqtt_interval(void)
+{
+    int interval = 0;
+    sm_stats_config_t *stats;
+
+    /* find minimum reporting_interval */
+    ds_tree_foreach(&stats_config_table, stats)
+    {
+        if (stats->schema.reporting_interval == 0) continue;
+        if (interval == 0 || stats->schema.reporting_interval < interval) {
+            interval = stats->schema.reporting_interval;
+        }
+    }
+    sm_mqtt_interval_set(interval);
+}
+
+static
 bool sm_update_stats_config(sm_stats_config_t *stats_cfg)
 {
     sm_stats_request_t              req;
@@ -271,6 +288,7 @@ bool sm_update_stats_config(sm_stats_config_t *stats_cfg)
     if(clock_gettime(CLOCK_REALTIME, &ts) != 0)
         return false;
 
+    sm_update_mqtt_interval();
 
     /* Search for existing radio entry and use fallback */
     sm_radio_state_t               *radio = NULL;

--- a/src/sm/src/sm_rssi_report.c
+++ b/src/sm/src/sm_rssi_report.c
@@ -645,7 +645,8 @@ bool sm_rssi_stats_process (
             return false;
         }
 
-        report_timer->repeat = request_ctx->reporting_interval;
+        report_timer->repeat = request_ctx->reporting_interval == -1 ?
+            1 : request_ctx->reporting_interval;
         sm_rssi_report_timer_set(report_timer, true);
         rssi_ctx->report_ts = get_timestamp();
 

--- a/src/sm/src/sm_survey_report.c
+++ b/src/sm/src/sm_survey_report.c
@@ -764,6 +764,10 @@ bool sm_survey_update_list_cb (
             if (channel_ctx->chan_index >= channel_ctx->chan_num) {
                 channel_ctx->chan_index = 0;
             }
+
+            if (survey_ctx->request.reporting_interval == -1) {
+                sm_survey_report_send(survey_ctx);
+            }
             break;
         case RADIO_SCAN_TYPE_FULL: /* Send report */
             sm_survey_report_send(survey_ctx);
@@ -1401,8 +1405,10 @@ bool sm_survey_init_cb (
         sm_survey_timer_set(update_timer, true);
     }
 
-    report_timer->repeat = request_ctx->reporting_interval;
-    sm_survey_timer_set(report_timer, true);
+    if (request_ctx->reporting_interval != -1) {
+        report_timer->repeat = request_ctx->reporting_interval;
+        sm_survey_timer_set(report_timer, true);
+    }
 
     survey_ctx->report_ts = get_timestamp();
 


### PR DESCRIPTION
The change was done in order to be able to collect fresh WiFi/device statistics in real-time.
The minimal delay between the statistics collecting and publishing is up to 1.1 seconds now.