### PR TITLE
um: Fixed possible memory leak in um_ovsdb.c

### DIFF
--- a/src/um/src/um_ovsdb.c
+++ b/src/um/src/um_ovsdb.c
@@ -333,7 +333,7 @@ static void callback_AWLAN_Node(
                         {
                            free(upg_url);
                            upg_url = NULL;
-                        }   
+                        }
                         upg_url = strdup(awlan_node->firmware_url);
                         um_start_download(upg_url, awlan_node->upgrade_dl_timer);
                     }

--- a/src/um/src/um_ovsdb.c
+++ b/src/um/src/um_ovsdb.c
@@ -329,6 +329,11 @@ static void callback_AWLAN_Node(
                 if (strlen(awlan_node->firmware_url) > 0)
                 {
                     if(upg_url == NULL || strncmp(upg_url, awlan_node->firmware_url, sizeof(awlan_node->firmware_url))){
+                        if(upg_url)
+                        {
+                           free(upg_url);
+                           upg_url = NULL;
+                        }   
                         upg_url = strdup(awlan_node->firmware_url);
                         um_start_download(upg_url, awlan_node->upgrade_dl_timer);
                     }


### PR DESCRIPTION
The second half of the If statement in line 331, implies that there is a case in which upg_url is not null (and therefore points to allocated memory) and will enter the consequence section where the var will be changed to a new portion of allocated memory without first freeing the memory it is currently pointing to.

Solutions:
1) (As showing in the PR) Upon entering the consequence section, check if upg_url is true, and if so, free the memory at that address and set the pointer to NULL.
OR
2) It may be better to fix the length of upg_url to the max length of the URL in the OVSDB table from which the field is derived. The string can then be "emptied" buy setting the first char to '\0' (zero-length string) and the string can be checked by checking the first byte is not '\0'. This will get away from allocated and freeing memory where not needed.