### PR TITLE
Maintain ordering in schema header files

### DIFF
--- a/src/lib/schema/schema.py
+++ b/src/lib/schema/schema.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import os
+from collections import OrderedDict
 
 DEFAULT_STRING_LEN = 128            # Default string length, if not a set or map
 DEFAULT_MAP_STRING_LEN = 64         # Default string length, if map or set
@@ -222,7 +223,7 @@ if not os.path.isfile(sys.argv[1]):
     raise
 
 with open(sys.argv[1]) as jsfile:
-    schema = json.load(jsfile);
+    schema = json.load(jsfile, object_pairs_hook=OrderedDict);
 
 # Some rudimentary checks
 if not "name" in schema.keys() or schema["name"] != "Open_vSwitch":


### PR DESCRIPTION
Prior to Python version 3.7, ordering in dictionaries is
nondeterminstic, so each time the schema header files are generated, the
ordering of C struct members may be different. This means that different
compilations will lay out these structures differently and programs
compiled separately will not be able to interoperate.

Maintain ordering by using OrderedDict when loading the json schema
files.