### PR TITLE
    dm: Make speed test command a kconfig setting

### DIFF
--- a/src/dm/kconfig/Kconfig.managers
+++ b/src/dm/kconfig/Kconfig.managers
@@ -16,4 +16,13 @@ if MANAGER_DM
         help
             This is the folder where PID files of the started processes will
             be stored. The files will be named [MANAGER_NAME].pid
+
+    config SPEED_TEST_CMD
+        string "Speed test command and options"
+        help
+            The command and command line options that execute a speed test.  Do not specify the path, the command must be located in $(PLUME_DIR)/tools.  Setting a command line enables speed test support.
+
+    config SPEEDTEST
+        bool
+        default y if SPEED_TEST_CMD != ""
 endif

--- a/src/dm/src/dm_st.c
+++ b/src/dm/src/dm_st.c
@@ -239,7 +239,7 @@ void dm_stupdate_cb(ovsdb_update_monitor_t *self)
                 }
 
                 char st_cmd[TARGET_BUFF_SZ];
-                sprintf(st_cmd, "%s/st_ookla -qlvJ", tools_dir);
+                sprintf(st_cmd, "%s/%s", tools_dir, CONFIG_SPEED_TEST_CMD);
                 if (false == pasync_ropen(EV_DEFAULT, st_config.testid, st_cmd, pa_cb))
                 {
                     LOG(ERR, "Error running pasync_ropen 1");


### PR DESCRIPTION
    Currently the speed test command and options are hardcoded in dm.  It
    is highly likely that as the speed test tool is updated that the
    command or it's options may change.  By moving the command and options
    to a kconfig setting we remove the hard coded string and provide
    configurability eliminating the need to modify the code when the
    command or its options change.