### PR TITLE
bm: fix bm_client error messages

### DIFF
--- a/src/bm/src/bm_client.c
+++ b/src/bm/src/bm_client.c
@@ -834,7 +834,7 @@ bm_client_add_to_all_groups(bm_client_t *client)
     bool            success = true;
 
     if (!(groups = bm_group_get_tree())) {
-        LOGE("bm_client_update_all_groups() failed to get group tree");
+        LOGE("bm_client_add_to_all_groups() failed to get group tree");
         return false;
     }
 

--- a/src/bm/src/bm_client.c
+++ b/src/bm/src/bm_client.c
@@ -876,7 +876,7 @@ bm_client_remove_from_all_groups(bm_client_t *client)
     bool            success = true;
 
     if (!(groups = bm_group_get_tree())) {
-        LOGE("bm_client_update_all_groups() failed to get group tree");
+        LOGE("bm_client_remove_from_all_groups() failed to get group tree");
         return false;
     }
 


### PR DESCRIPTION
The log messages in the bm_client_add_to_all_groups() and bm_client_remove_from_all_groups() functions should not say bm_client_update_all_groups().