### PR TITLE
cpm: missing release file descriptor

### DIFF
--- a/src/cpm/src/captive_portal_proxy.c
+++ b/src/cpm/src/captive_portal_proxy.c
@@ -216,6 +216,7 @@ cportal_proxy_write_other_config(struct cportal *self)
     if (!ret)
     {
         LOG(ERR, "%s: Error parsing configured url", __func__);
+        fclose(fconf);
         return false;
     }
 


### PR DESCRIPTION
The error handler does not release fd "fconf" before return.

Signed-off-by: Kenneth Lu <kuohsianglu@gmail.com>