### PR TITLE
bm: the same expression of EVSCHED_FIND_BY_FUNC

### DIFF
--- a/src/bm/src/bm_client.c
+++ b/src/bm/src/bm_client.c
@@ -1998,7 +1998,7 @@ bm_client_state_task( void *arg )
     bm_client_t         *client = arg;
 
     evsched_task_cancel_by_find( bm_client_state_task, client,
-                               ( EVSCHED_FIND_BY_FUNC | EVSCHED_FIND_BY_FUNC ) );
+                               ( EVSCHED_FIND_BY_ARG | EVSCHED_FIND_BY_FUNC ) );
 
     if( client->state == BM_CLIENT_STATE_CONNECTED ) {
         LOGT( "Client '%s' connected, client state machine in proper state",


### PR DESCRIPTION
Fixed the same expression on both side of '|', it should be EVSCHED_FIND_BY_ARG.

Signed-off-by: Kenneth Lu <kuohsianglu@gmail.com>