### PR TITLE
[WROUTSAGE-1338] Integrate patch to ensure option 15 has correct value

### DIFF
--- a/src/maptm/src/maptm.h
+++ b/src/maptm/src/maptm.h
@@ -45,17 +45,20 @@
 
 #define MAPT_IFC_WAN "br-wan"
 #define MAPT_IFC_LAN "BR_LAN"
+#define MAPTM_TIMEOUT_INTERVAL 5
 
 extern int maptm_ovsdb_init(void);
 extern bool maptm_ovsdb_nfm_add_rules(void);
 extern bool maptm_ovsdb_nfm_del_rules(void);
+extern void maptm_timerStart(void);
+extern void maptm_timerStop(void);
 extern void maptm_disableAccess(void);
 extern void maptm_eligibilityStart(int WanConfig);
 extern bool config_mapt(void);
 extern bool stop_mapt(void);
 extern void Parse_95_option(void);
 extern void maptm_eligibilityStop(void);
-extern void maptm_wan_mode(void);
+extern void maptm_callback_Timer(void);
 extern int maptm_dhcp_option_init(void);
 extern bool maptm_dhcp_option_update_15_option(bool maptSupport);
 extern bool maptm_dhcp_option_update_95_option(bool maptSupport);

--- a/src/maptm/src/maptm_ovsdb.c
+++ b/src/maptm/src/maptm_ovsdb.c
@@ -127,6 +127,8 @@ bool maptm_persistent(void)
         {
             LOGE("Failed when setting persistent storage value");
             strucWanConfig.mapt_support = true;
+            maptm_dhcp_option_update_15_option(strucWanConfig.mapt_support);
+            maptm_dhcp_option_update_95_option(strucWanConfig.mapt_support);
             goto out;
         }
     }
@@ -137,6 +139,8 @@ bool maptm_persistent(void)
     {
         strucWanConfig.mapt_support = false;
     }
+    maptm_dhcp_option_update_15_option(strucWanConfig.mapt_support);
+    maptm_dhcp_option_update_95_option(strucWanConfig.mapt_support);
     ret = true;
 
 out:


### PR DESCRIPTION
[WROUTSAGE-1342] MAP-T: Use a timer to determine the DHCPv4 client needs to be started

Root cause: Use timer for starting DHCPv4

Solution: Use timer for starting DHCPv4

Test scenario:
1- Check that DHCPv4 is starting when DHCPv6 Server is down

Test results: Ok