### PR TITLE
MAPTM: Add DHCP init hook

### DIFF
--- a/src/maptm/kconfig/Kconfig.managers
+++ b/src/maptm/kconfig/Kconfig.managers
@@ -22,3 +22,8 @@ menuconfig MANAGER_MAPTM
         string "MAPTM Eligibility mode"
         default "dualstack"
         
+    config MAPTM_DHCP_OPT_INIT_HOOK
+        depends on MANAGER_MAPTM
+        bool "Enable additional DHCP option init in MAPTM"
+        default n
+

--- a/src/maptm/src/maptm.h
+++ b/src/maptm/src/maptm.h
@@ -60,6 +60,10 @@ extern int maptm_dhcp_option_init(void);
 extern bool maptm_dhcp_option_update_15_option(bool maptSupport);
 extern bool maptm_dhcp_option_update_95_option(bool maptSupport);
 int maptm_main(int argc, char **argv);
+#if defined(CONFIG_MAPTM_DHCP_OPT_INIT_HOOK)
+extern bool maptm_dhcp_option_init_hook(void);
+#endif
+
 #define MAPTM_NO_ELIGIBLE_NO_IPV6 0x00
 #define MAPTM_NO_ELIGIBLE_IPV6 0x01
 #define MAPTM_ELIGIBLE_NO_IPV6 0x10

--- a/src/maptm/src/maptm_eligibility.c
+++ b/src/maptm/src/maptm_eligibility.c
@@ -493,6 +493,11 @@ int maptm_dhcp_option_init(void)
 
     OVSDB_TABLE_MONITOR(DHCP_Option, false);
     OVSDB_TABLE_MONITOR(IPv6_Address, false);
+
+#if defined(CONFIG_MAPTM_DHCP_OPT_INIT_HOOK)
+    maptm_dhcp_option_init_hook(); // If needed, define using the vendor override mechanism
+#endif
+
     return 0;
 }
 


### PR DESCRIPTION
Add an optional DHCP init hook to MAPTM so vendor specific initialization for DHCP can be performed. The intent is that a vendor will use the override.mk mechanism to implement `maptm_dhcp_option_init_hook()`.