### PR TITLE
kconfig: Added kconfig includes for service provider layer

### DIFF
--- a/kconfig/Kconfig
+++ b/kconfig/Kconfig
@@ -210,6 +210,10 @@ menu "Common"
 
 endmenu
 
+menu "Service Provider Configuration"
+    orsource "../service-provider/*/kconfig/Kconfig.service-provider"
+endmenu
+
 menu "Platform Configuration"
     orsource "Kconfig.platform"
     orsource "../platform/*/kconfig/Kconfig.platform"

--- a/kconfig/Kconfig.managers
+++ b/kconfig/Kconfig.managers
@@ -28,5 +28,6 @@ source "src/ltem/kconfig/Kconfig.managers"
 #
 # Include platform/vendor managers
 #
+osource "service-provider/*/kconfig/Kconfig.managers"
 osource "platform/*/kconfig/Kconfig.managers"
 osource "vendor/*/kconfig/Kconfig.managers"


### PR DESCRIPTION
kconfig includes which allow for service provider menu and managers
are missing from current master. `kconfig/Kconfig` was modified to
allow for a service provider menu similar to platform with the
exception of no default service provider. And
`kconfig/Kconfig.managers` was modified to include manager kconfig
defined by the service provider.

Since service provider is a many to many or none relationship with
platform it is best to have the includes in the core opensync portion.