### PR TITLE
Update nm2_dhcp_lease.c

### DIFF
--- a/src/nm2/src/nm2_dhcp_lease.c
+++ b/src/nm2/src/nm2_dhcp_lease.c
@@ -273,7 +273,11 @@ bool nm2_dhcp_lease_notify(
     strscpy(sdl.fingerprint, dl->dl_fingerprint, sizeof(sdl.fingerprint));
 
     sdl.vendor_class_exists = true;
-    strscpy(sdl.vendor_class, dl->dl_vendorclass, sizeof(sdl.vendor_class));
+    // Check for and remove leading and trailing double quotes
+    if (1 != sscanf(dl->dl_vendorclass, "\"%128[^\"]\"", sdl.vendor_class))
+    {   
+        strscpy(sdl.vendor_class, dl->dl_vendorclass, sizeof(sdl.vendor_class));
+    }  
 
     /* A lease time of 0 indicates that this entry should be deleted */
     sdl.lease_time_exists = true;


### PR DESCRIPTION
Change: removing leading and trailing "" from the vendorclass
Subject: [EXTCS-157] vendorclass is having extra "" in DHCP_leased_IP for all the RDKB GW's