### PR TITLE
lib: Add manager logs to separate files under tmp

### DIFF
--- a/src/lib/log/src/log.c
+++ b/src/lib/log/src/log.c
@@ -107,6 +107,7 @@ const char* log_get_name()
 }
 
 static void _log_sink_severity_set_default(log_sink_t sink);
+static FILE* tmp_log_file = NULL;
 
 /**
  * Severity per-module
@@ -187,6 +188,12 @@ bool log_open(char *name, int flags)
 
     traceback_enabled = logger_traceback_new(&logger_traceback);
     log_register_logger(&logger_traceback);
+
+    if (access("/nvram/opensync_tmp_logging", R_OK) == 0) {
+        char fn[64];
+        sprintf(fn, "/tmp/opensync.%s.log", name);
+        tmp_log_file = fopen(fn, "w+");
+    }
 
     return true;
 }
@@ -427,6 +434,10 @@ void log_close()
 {
     LOG_MODULE_MESSAGE(NOTICE, LOG_MODULE_ID_COMMON, "log functionality closed");
     log_enabled = false;
+    if (tmp_log_file) {
+        fclose(tmp_log_file);
+        tmp_log_file = NULL;
+    }
 }
 
 static bool log_any_sink_match(log_severity_t sev, log_module_t module)
@@ -575,6 +586,12 @@ void mlog(log_severity_t sev,
     msg.lm_tag = se_tag;
     msg.lm_timestamp = timestr;
     msg.lm_text = buff;
+
+    if (tmp_log_file) {
+        fprintf(tmp_log_file, "%d %d %s %s %s %s\n", 
+            msg.lm_severity, msg.lm_module, msg.lm_module_name, 
+            msg.lm_tag, msg.lm_timestamp, msg.lm_text);
+    }
 
     /* Feed messages to the registered loggers */
     logger_t *plog;


### PR DESCRIPTION
Added ability for OpenSync managers write logs to /tmp/<manager name>.log instead of /var/log/user

Test:
   Need to create file /nvram/opensync_tmp_logging and on next OpenSync start we'll have /tmp/opensync.<<Manager-Name>>.log files.
   Need to note it's pure debug feature - logs written to tmpfs get big enough fast, see below stats captured at 8 min of running after boot.
   Need to note also, that logs will be still coming to /var/log/user.