### PR TITLE
Restart manager if using plan b

### DIFF
--- a/src/dm/src/dm_manager.c
+++ b/src/dm/src/dm_manager.c
@@ -841,7 +841,7 @@ void dm_manager_child_fn(struct ev_loop *loop, ev_child *w, int revents)
 
     /* check if the on of the manager processes had crashed     */
     /* ignore managers stop due to user actions                 */
-    if (!ignore_signal(w->rstatus) || dm->dm_restart_always)
+    if (!ignore_signal(w->rstatus) || dm->dm_restart_always || dm->dm_plan_b)
     {
         LOG(NOTICE, "Manager '%s' terminated, signal: %d, restarting in %d seconds.",
                     dm->dm_name,


### PR DESCRIPTION
Hi

A PR on the Device manager.

When a manger as a `needs_plan_b=true` and get stopped/killed, it is not restarted immedialty.
It is restarted by the watchdog.

This PR make that when there is `needs_plan_b=true`, it will restart.
Another fix would be to replace every `needs_plan_b=true` by `always_restart=true;needs_plan_b=true`

Thanks

Note that `dm_plan_b` is only used in
- dm_manager_restart_fn() - which is trigger in two case: the process exited (badly or correclty) and if the process as `always_restart=true`
- dm_manager_kill()
